### PR TITLE
Fix Incorrect Deployment Controls for StatefulSet Pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The command removes all the banyandb components associated with the chart and de
 | cluster.data.grpcSvc.annotations | object | `{}` |  |
 | cluster.data.grpcSvc.labels | object | `{}` |  |
 | cluster.data.grpcSvc.port | int | `17912` |  |
-| cluster.data.name | string | `"banyandb"` |  |
 | cluster.data.nodeSelector | list | `[]` |  |
 | cluster.data.podAnnotations | string | `nil` |  |
 | cluster.data.podDisruptionBudget | object | `{}` |  |
@@ -60,7 +59,6 @@ The command removes all the banyandb components associated with the chart and de
 | cluster.data.replicas | int | `3` |  |
 | cluster.data.resources.limits | list | `[]` |  |
 | cluster.data.resources.requests | list | `[]` |  |
-| cluster.data.role | string | `"data"` |  |
 | cluster.data.securityContext | object | `{}` |  |
 | cluster.data.sidecar | list | `[]` |  |
 | cluster.data.tolerations | list | `[]` |  |
@@ -83,7 +81,6 @@ The command removes all the banyandb components associated with the chart and de
 | cluster.liaison.ingress.labels | object | `{}` |  |
 | cluster.liaison.ingress.rules | list | `[]` |  |
 | cluster.liaison.ingress.tls | list | `[]` |  |
-| cluster.liaison.name | string | `"banyandb"` |  |
 | cluster.liaison.nodeSelector | list | `[]` |  |
 | cluster.liaison.podAnnotations | string | `nil` |  |
 | cluster.liaison.podDisruptionBudget | object | `{}` |  |
@@ -91,7 +88,6 @@ The command removes all the banyandb components associated with the chart and de
 | cluster.liaison.replicas | int | `2` |  |
 | cluster.liaison.resources.limits | list | `[]` |  |
 | cluster.liaison.resources.requests | list | `[]` |  |
-| cluster.liaison.role | string | `"liaison"` |  |
 | cluster.liaison.securityContext | object | `{}` |  |
 | cluster.liaison.tolerations | list | `[]` |  |
 | etcd.auth.client.caFilename | string | `""` |  |
@@ -130,7 +126,6 @@ The command removes all the banyandb components associated with the chart and de
 | standalone.ingress.labels | object | `{}` |  |
 | standalone.ingress.rules | list | `[]` |  |
 | standalone.ingress.tls | list | `[]` |  |
-| standalone.name | string | `"banyandb"` |  |
 | standalone.nodeSelector | list | `[]` |  |
 | standalone.podAnnotations.example | string | `"banyandb-foo"` |  |
 | standalone.podDisruptionBudget | object | `{}` |  |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -22,25 +22,23 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.cluster.liaison.name }}"
+    component: liaison
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    role: {{ .Values.cluster.liaison.role }}
   name: {{ template "banyandb.fullname" . }}
 spec:
   replicas: {{ .Values.cluster.liaison.replicas }}
   selector:
     matchLabels:
       app: {{ template "banyandb.name" . }}
-      component: "{{ .Values.cluster.liaison.name }}"
+      component: liaison
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "banyandb.name" . }}
-        component: "{{ .Values.cluster.liaison.name }}"
+        component: liaison
         release: {{ .Release.Name }}
-        role: {{ .Values.cluster.liaison.role }}
       {{- if .Values.cluster.liaison.podAnnotations }}
       annotations:
 {{ toYaml .Values.cluster.liaison.podAnnotations | indent 8 }}
@@ -53,7 +51,7 @@ spec:
       {{- end }}
       priorityClassName: {{ .Values.cluster.liaison.priorityClassName }}
       containers:
-        - name: {{ .Values.cluster.liaison.name }}
+        - name: liaison
           image: {{ .Values.image.repository }}:{{ required "banyandb.image.tag is required" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/chart/templates/grpc_service.yaml
+++ b/chart/templates/grpc_service.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.standalone.grpcSvc.labels }}
@@ -40,7 +40,7 @@ spec:
       name: grpc
   selector:
     app: {{ template "banyandb.name" . }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     release: {{ .Release.Name }}
 {{- end }}
 
@@ -52,7 +52,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.cluster.liaison.name }}"
+    component: liaison
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.cluster.liaison.grpcSvc.labels }}
@@ -69,7 +69,6 @@ spec:
       name: grpc
   selector:
     app: {{ template "banyandb.name" . }}
-    component: "{{ .Values.cluster.liaison.name }}"
+    component: liaison
     release: {{ .Release.Name }}
-    role: liaison
 {{- end }}

--- a/chart/templates/http_service.yaml
+++ b/chart/templates/http_service.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.standalone.httpSvc.labels }}
@@ -40,7 +40,7 @@ spec:
       name: http
   selector:
     app: {{ template "banyandb.name" . }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     release: {{ .Release.Name }}
   {{- if .Values.standalone.httpSvc.externalIPs }}
   externalIPs:
@@ -67,7 +67,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.cluster.liaison.name }}"
+    component: liaison
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.cluster.liaison.httpSvc.labels }}
@@ -84,9 +84,8 @@ spec:
       name: http
   selector:
     app: {{ template "banyandb.name" . }}
-    component: "{{ .Values.cluster.liaison.name }}"
+    component: liaison
     release: {{ .Release.Name }}
-    role: liaison
   {{- if .Values.cluster.liaison.httpSvc.externalIPs }}
   externalIPs:
     {{- range $v := .Values.cluster.liaison.httpSvc.externalIPs }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -28,7 +28,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.standalone.ingress.labels }}

--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -27,7 +27,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
@@ -70,7 +70,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.cluster.liaison.name }}"
+    component: liaison
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
@@ -111,7 +111,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.data.name }}"
+    component: data
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -23,7 +23,6 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.standalone.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.standalone.name }}"
+    component: standalone
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "banyandb.fullname" . }}
@@ -32,13 +32,13 @@ spec:
   selector:
     matchLabels:
       app: {{ template "banyandb.name" . }}
-      component: "{{ .Values.standalone.name }}"
+      component: standalone
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "banyandb.name" . }}
-        component: "{{ .Values.standalone.name }}"
+        component: standalone
         release: {{ .Release.Name }}
       {{- if .Values.standalone.podAnnotations }}
       annotations:
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       priorityClassName: {{ .Values.standalone.priorityClassName }}
       containers:
-        - name: {{ .Values.standalone.name }}
+        - name: standalone
           image: {{ .Values.image.repository }}:{{ required "banyandb.image.tag is required" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
@@ -259,7 +259,7 @@ metadata:
   labels:
     app: {{ template "banyandb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.cluster.data.name }}"
+    component: data
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "banyandb.fullname" . }}
@@ -269,16 +269,14 @@ spec:
   selector:
     matchLabels:
       app: {{ template "banyandb.name" . }}
-      component: "{{ .Values.cluster.data.name }}"
+      component: data
       release: {{ .Release.Name }}
-      role: {{ .Values.cluster.data.role }}
   template:
     metadata:
       labels:
         app: {{ template "banyandb.name" . }}
-        component: "{{ .Values.cluster.data.name }}"
+        component: data
         release: {{ .Release.Name }}
-        role: {{ .Values.cluster.data.role }}
       {{- if .Values.cluster.data.podAnnotations }}
       annotations:
 {{ toYaml .Values.cluster.data.podAnnotations | indent 8 }}
@@ -291,7 +289,7 @@ spec:
       {{- end }}
       priorityClassName: {{ .Values.cluster.data.priorityClassName }}
       containers:
-        - name: {{ .Values.cluster.data.name }}
+        - name: data
           image: {{ .Values.image.repository }}:{{ required "banyandb.image.tag is required" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,7 +24,6 @@ image:
 
 standalone:
   enabled: false
-  name: banyandb
   podAnnotations: 
     example: banyandb-foo
   securityContext: {}
@@ -127,8 +126,6 @@ cluster:
   enabled: true
   etcdEndpoints: []
   liaison:
-    name: banyandb
-    role: liaison
     replicas: 2
     podAnnotations: 
       # example: banyandb-foo
@@ -224,7 +221,6 @@ cluster:
 
   data:
     name: banyandb
-    role: data
     replicas: 3
     podAnnotations: 
       # example: banyandb-foo

--- a/test/e2e/values.cluster.yaml
+++ b/test/e2e/values.cluster.yaml
@@ -26,8 +26,6 @@ cluster:
   enabled: true
   etcdEndpoints: []
   liaison:
-    name: banyandb
-    role: liaison
     replicas: 1
     podAnnotations: 
       example: banyandb-foo
@@ -122,8 +120,6 @@ cluster:
         #   secretName: tls-secret
 
   data:
-    name: banyandb
-    role: data
     replicas: 1
     podAnnotations: 
       example: banyandb-foo


### PR DESCRIPTION
The pods created by deployment and stateful set have identical labels. 