### PR TITLE
Introduce startup probe to deployments

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.14.3
 digest: sha256:31aacd1ae011febfa82522a1777fd2f36a52529bea2e343bacb0060c51068906
-generated: "2024-03-01T09:44:38.864211193+08:00"
+generated: "2024-09-14T06:34:19.861488669Z"

--- a/chart/templates/liaison_deployment.yaml
+++ b/chart/templates/liaison_deployment.yaml
@@ -137,7 +137,20 @@ spec:
             timeoutSeconds: {{ .Values.cluster.liaison.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.cluster.liaison.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.cluster.liaison.livenessProbe.failureThreshold }}
-          
+          startupProbe:
+            httpGet:
+              path: /api/healthz
+              port: 17913
+              {{- if .Values.cluster.liaison.tls }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.cluster.liaison.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cluster.liaison.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.cluster.liaison.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.cluster.liaison.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.cluster.liaison.startupProbe.failureThreshold }}
           {{- if.Values.cluster.liaison.resources }}
           resources:
             {{- if.Values.cluster.liaison.resources.requests }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -161,6 +161,7 @@ spec:
             {{- end }}
             {{- end }}
 
+            {{- if .Values.standalone.tls -}}
             {{- if .Values.standalone.tls.grpcSecretName }}
             - mountPath: /etc/tls/{{ .Values.standalone.tls.grpcSecretName }}
               name: {{ .Values.standalone.tls.grpcSecretName }}-volume
@@ -169,6 +170,7 @@ spec:
             - mountPath: /etc/tls/{{ .Values.standalone.tls.httpSecretName }}
               name: {{ .Values.standalone.tls.httpSecretName }}-volume
             {{- end }}
+            {{- end -}}
           {{- end }}
 
       {{- if .Values.standalone.tls }}

--- a/chart/templates/ui_deployment.yaml
+++ b/chart/templates/ui_deployment.yaml
@@ -121,6 +121,20 @@ spec:
             timeoutSeconds: {{ .Values.cluster.ui.standalone.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.cluster.ui.standalone.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.cluster.ui.standalone.livenessProbe.failureThreshold }}
+          startupProbe:
+            httpGet:
+              path: /api/healthz
+              port: 17913
+              {{- if .Values.cluster.ui.standalone.tls }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.cluster.ui.standalone.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cluster.ui.standalone.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.cluster.ui.standalone.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.cluster.ui.standalone.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.cluster.ui.standalone.startupProbe.failureThreshold }}
           
           {{- if.Values.cluster.ui.standalone.resources }}
           resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -245,6 +245,13 @@ cluster:
       successThreshold: 1
       failureThreshold: 5
 
+    startupProbe:
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 60
+
   data:
     name: banyandb
     replicas: 3
@@ -444,6 +451,13 @@ cluster:
         timeoutSeconds: 5
         successThreshold: 1
         failureThreshold: 5
+
+      startupProbe:
+        initialDelaySeconds: 0
+        periodSeconds: 10
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 60
 
 storage:
   enabled: false

--- a/test/e2e/values.cluster.yaml
+++ b/test/e2e/values.cluster.yaml
@@ -140,6 +140,13 @@ cluster:
       successThreshold: 1
       failureThreshold: 60
 
+    startupProbe:
+      initialDelaySeconds: 0
+      periodSeconds: 5
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 60
+
   data:
     replicas: 1
     podAnnotations:
@@ -229,6 +236,13 @@ cluster:
 
     readinessProbe:
       initialDelaySeconds: 20
+      periodSeconds: 5
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 60
+
+    startupProbe:
+      initialDelaySeconds: 0
       periodSeconds: 5
       timeoutSeconds: 5
       successThreshold: 1
@@ -340,6 +354,13 @@ cluster:
         timeoutSeconds: 5
         successThreshold: 1
         failureThreshold: 5
+
+      startupProbe:
+        initialDelaySeconds: 0
+        periodSeconds: 5
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 60
 
 storage:
   enabled: false

--- a/test/e2e/values.standalone.yaml
+++ b/test/e2e/values.standalone.yaml
@@ -106,6 +106,13 @@ standalone:
     successThreshold: 1
     failureThreshold: 60
 
+  startupProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 60
+
   grpcSvc:
     labels: {}
     annotations: {}


### PR DESCRIPTION
After https://github.com/apache/skywalking-banyandb/pull/538 is merged, the deployment could include a startup probe to wait for etcd to be ready.