### PR TITLE
Set etcd's reposiotry to "bitnamilegacy" 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Release Notes.
 - Implement volume permissions init containers for proper file ownership and permissions on mounted volumes
 - Add the mount target for the trace mode
 - Add `auth` to configure the basic credential file.
+- Set etcd's reposiotry to "bitnamilegacy". Bitnami removed non-hardened, Debian-based software images in its free tier under https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications
 
 #### Chores
 

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.0.4
-digest: sha256:89059bc1e608d19e843cadb665bf6467858908eaea4d8f382b5046cdbc901f51
-generated: "2025-08-12T03:26:24.777446502Z"
+  version: 12.0.18
+digest: sha256:428d19828d309ec37ac9e569328eda161160b9a42cb7af3b6a3a44c738720fb2
+generated: "2025-10-03T07:45:44.426744+08:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -23,6 +23,6 @@ sources:
 - https://github.com/apache/skywalking-banyandb-helm
 dependencies:
 - name: etcd
-  version: 12.0.4
+  version: 12.0.18
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: etcd.enabled

--- a/chart/values-lifecycle.yaml
+++ b/chart/values-lifecycle.yaml
@@ -869,6 +869,10 @@ etcd:
   ## @param etcd.replicaCount Number of etcd replicas
   ##
   replicaCount: 1
+  ## @param etcd.image.repository Docker repository for etcd
+  ##
+  image:
+    repository: bitnamilegacy/etcd
   ## @section Authentication configuration for etcd
   ##
   auth:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -855,7 +855,7 @@ storage:
     persistentVolumeClaims:
     ## @param storage.standalone.persistentVolumeClaims[0].mountTargets Mount targets for the PVC
     ##
-    - mountTargets: [ "measure", "stream", "metadata", "property" ]
+    - mountTargets: [ "measure", "stream", "metadata", "property", "trace" ]
       ## @param storage.standalone.persistentVolumeClaims[0].claimName Name of the PVC
       claimName: standalone-data
       ## @param storage.standalone.persistentVolumeClaims[0].size Size of the PVC

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -801,6 +801,24 @@ storage:
       storageClass: null
       ## @param storage.data.persistentVolumeClaims[2].volumeMode Volume mode for the PVC
       volumeMode: Filesystem
+    ## @param storage.data.persistentVolumeClaims[3].mountTargets Mount targets for the PVC
+    - mountTargets: [ "trace" ]
+      ## @param storage.data.persistentVolumeClaims[3].nodeRole Node role this PVC is bound to
+      ##
+      nodeRole: hot
+      ## @param storage.data.persistentVolumeClaims[3].existingClaimName Existing PVC name (if any)
+      existingClaimName: null
+      ## @param storage.data.persistentVolumeClaims[3].claimName Name of the PVC
+      claimName: hot-trace-data
+      ## @param storage.data.persistentVolumeClaims[3].size Size of the PVC
+      size: 50Gi
+      ## @param storage.data.persistentVolumeClaims[3].accessModes Access modes for the PVC
+      accessModes:
+      - ReadWriteOnce
+      ## @param storage.data.persistentVolumeClaims[3].storageClass Storage class for the PVC
+      storageClass: null
+      ## @param storage.data.persistentVolumeClaims[3].volumeMode Volume mode for the PVC
+      volumeMode: Filesystem
 
   ## Liaison storage configuration
   ##
@@ -813,7 +831,7 @@ storage:
     persistentVolumeClaims:
     ## @param storage.liaison.persistentVolumeClaims[0].mountTargets Mount targets for the PVC
     ##
-    - mountTargets: [ "measure", "stream" ]
+    - mountTargets: [ "measure", "stream", "trace" ]
       ## @param storage.liaison.persistentVolumeClaims[0].claimName Name of the PVC
       claimName: liaison-data
       ## @param storage.liaison.persistentVolumeClaims[0].size Size of the PVC
@@ -872,6 +890,10 @@ etcd:
   ## @param etcd.replicaCount Number of etcd replicas
   ##
   replicaCount: 1
+  ## @param etcd.image.repository Docker repository for etcd
+  ##
+  image:
+    repository: bitnamilegacy/etcd
   ## @section Authentication configuration for etcd
   ##
   auth:

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -252,50 +252,58 @@ The content of this document describes the parameters that can be configured in 
 
 ### Storage configuration for persistent volumes
 
-| Name                                                        | Description                                             | Value                                        |
-| ----------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------- |
-| `storage.data.enabled`                                      | Enable persistent storage for data nodes (boolean)      | `true`                                       |
-| `storage.data.persistentVolumeClaims`                       | List of PVC configurations for data nodes               |                                              |
-| `storage.data.persistentVolumeClaims[0].mountTargets`       | Mount targets for the PVC                               | `["measure"]`                                |
-| `storage.data.persistentVolumeClaims[0].nodeRole`           | Node role this PVC is bound to (hot, warm, cold)        | `hot`                                        |
-| `storage.data.persistentVolumeClaims[0].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                        |
-| `storage.data.persistentVolumeClaims[0].claimName`          | Name of the PVC                                         | `hot-measure-data`                           |
-| `storage.data.persistentVolumeClaims[0].size`               | Size of the PVC                                         | `50Gi`                                       |
-| `storage.data.persistentVolumeClaims[0].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                          |
-| `storage.data.persistentVolumeClaims[0].storageClass`       | Storage class for the PVC                               | `nil`                                        |
-| `storage.data.persistentVolumeClaims[0].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                 |
-| `storage.data.persistentVolumeClaims[1].mountTargets`       | Mount targets for the PVC                               | `["stream"]`                                 |
-| `storage.data.persistentVolumeClaims[1].nodeRole`           | Node role this PVC is bound to                          | `hot`                                        |
-| `storage.data.persistentVolumeClaims[1].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                        |
-| `storage.data.persistentVolumeClaims[1].claimName`          | Name of the PVC                                         | `hot-stream-data`                            |
-| `storage.data.persistentVolumeClaims[1].size`               | Size of the PVC                                         | `50Gi`                                       |
-| `storage.data.persistentVolumeClaims[1].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                          |
-| `storage.data.persistentVolumeClaims[1].storageClass`       | Storage class for the PVC                               | `nil`                                        |
-| `storage.data.persistentVolumeClaims[1].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                 |
-| `storage.data.persistentVolumeClaims[2].mountTargets`       | Mount targets for the PVC                               | `["property"]`                               |
-| `storage.data.persistentVolumeClaims[2].nodeRole`           | Node role this PVC is bound to                          | `hot`                                        |
-| `storage.data.persistentVolumeClaims[2].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                        |
-| `storage.data.persistentVolumeClaims[2].claimName`          | Name of the PVC                                         | `hot-property-data`                          |
-| `storage.data.persistentVolumeClaims[2].size`               | Size of the PVC                                         | `5Gi`                                        |
-| `storage.data.persistentVolumeClaims[2].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                          |
-| `storage.data.persistentVolumeClaims[2].storageClass`       | Storage class for the PVC                               | `nil`                                        |
-| `storage.data.persistentVolumeClaims[2].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                 |
-| `storage.liaison.enabled`                                   | Enable persistent storage for liaison nodes (boolean)   | `true`                                       |
-| `storage.liaison.persistentVolumeClaims`                    | List of PVC configurations for liaison nodes            |                                              |
-| `storage.liaison.persistentVolumeClaims[0].mountTargets`    | Mount targets for the PVC                               | `["measure","stream"]`                       |
-| `storage.liaison.persistentVolumeClaims[0].claimName`       | Name of the PVC                                         | `liaison-data`                               |
-| `storage.liaison.persistentVolumeClaims[0].size`            | Size of the PVC                                         | `10Gi`                                       |
-| `storage.liaison.persistentVolumeClaims[0].accessModes`     | Access modes for the PVC                                | `["ReadWriteOnce"]`                          |
-| `storage.liaison.persistentVolumeClaims[0].storageClass`    | Storage class for the PVC                               | `nil`                                        |
-| `storage.liaison.persistentVolumeClaims[0].volumeMode`      | Volume mode for the PVC                                 | `Filesystem`                                 |
-| `storage.standalone.enabled`                                | Enable persistent storage for standalone mode (boolean) | `false`                                      |
-| `storage.standalone.persistentVolumeClaims`                 | List of PVC configurations for standalone               |                                              |
-| `storage.standalone.persistentVolumeClaims[0].mountTargets` | Mount targets for the PVC                               | `["measure","stream","metadata","property"]` |
-| `storage.standalone.persistentVolumeClaims[0].claimName`    | Name of the PVC                                         | `standalone-data`                            |
-| `storage.standalone.persistentVolumeClaims[0].size`         | Size of the PVC                                         | `200Gi`                                      |
-| `storage.standalone.persistentVolumeClaims[0].accessModes`  | Access modes for the PVC                                | `["ReadWriteOnce"]`                          |
-| `storage.standalone.persistentVolumeClaims[0].storageClass` | Storage class for the PVC                               | `nil`                                        |
-| `storage.standalone.persistentVolumeClaims[0].volumeMode`   | Volume mode for the PVC                                 | `Filesystem`                                 |
+| Name                                                        | Description                                             | Value                                                |
+| ----------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
+| `storage.data.enabled`                                      | Enable persistent storage for data nodes (boolean)      | `true`                                               |
+| `storage.data.persistentVolumeClaims`                       | List of PVC configurations for data nodes               |                                                      |
+| `storage.data.persistentVolumeClaims[0].mountTargets`       | Mount targets for the PVC                               | `["measure"]`                                        |
+| `storage.data.persistentVolumeClaims[0].nodeRole`           | Node role this PVC is bound to (hot, warm, cold)        | `hot`                                                |
+| `storage.data.persistentVolumeClaims[0].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                                |
+| `storage.data.persistentVolumeClaims[0].claimName`          | Name of the PVC                                         | `hot-measure-data`                                   |
+| `storage.data.persistentVolumeClaims[0].size`               | Size of the PVC                                         | `50Gi`                                               |
+| `storage.data.persistentVolumeClaims[0].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                                  |
+| `storage.data.persistentVolumeClaims[0].storageClass`       | Storage class for the PVC                               | `nil`                                                |
+| `storage.data.persistentVolumeClaims[0].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                         |
+| `storage.data.persistentVolumeClaims[1].mountTargets`       | Mount targets for the PVC                               | `["stream"]`                                         |
+| `storage.data.persistentVolumeClaims[1].nodeRole`           | Node role this PVC is bound to                          | `hot`                                                |
+| `storage.data.persistentVolumeClaims[1].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                                |
+| `storage.data.persistentVolumeClaims[1].claimName`          | Name of the PVC                                         | `hot-stream-data`                                    |
+| `storage.data.persistentVolumeClaims[1].size`               | Size of the PVC                                         | `50Gi`                                               |
+| `storage.data.persistentVolumeClaims[1].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                                  |
+| `storage.data.persistentVolumeClaims[1].storageClass`       | Storage class for the PVC                               | `nil`                                                |
+| `storage.data.persistentVolumeClaims[1].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                         |
+| `storage.data.persistentVolumeClaims[2].mountTargets`       | Mount targets for the PVC                               | `["property"]`                                       |
+| `storage.data.persistentVolumeClaims[2].nodeRole`           | Node role this PVC is bound to                          | `hot`                                                |
+| `storage.data.persistentVolumeClaims[2].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                                |
+| `storage.data.persistentVolumeClaims[2].claimName`          | Name of the PVC                                         | `hot-property-data`                                  |
+| `storage.data.persistentVolumeClaims[2].size`               | Size of the PVC                                         | `5Gi`                                                |
+| `storage.data.persistentVolumeClaims[2].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                                  |
+| `storage.data.persistentVolumeClaims[2].storageClass`       | Storage class for the PVC                               | `nil`                                                |
+| `storage.data.persistentVolumeClaims[2].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                         |
+| `storage.data.persistentVolumeClaims[3].mountTargets`       | Mount targets for the PVC                               | `["trace"]`                                          |
+| `storage.data.persistentVolumeClaims[3].nodeRole`           | Node role this PVC is bound to                          | `hot`                                                |
+| `storage.data.persistentVolumeClaims[3].existingClaimName`  | Existing PVC name (if any)                              | `nil`                                                |
+| `storage.data.persistentVolumeClaims[3].claimName`          | Name of the PVC                                         | `hot-trace-data`                                     |
+| `storage.data.persistentVolumeClaims[3].size`               | Size of the PVC                                         | `50Gi`                                               |
+| `storage.data.persistentVolumeClaims[3].accessModes`        | Access modes for the PVC                                | `["ReadWriteOnce"]`                                  |
+| `storage.data.persistentVolumeClaims[3].storageClass`       | Storage class for the PVC                               | `nil`                                                |
+| `storage.data.persistentVolumeClaims[3].volumeMode`         | Volume mode for the PVC                                 | `Filesystem`                                         |
+| `storage.liaison.enabled`                                   | Enable persistent storage for liaison nodes (boolean)   | `true`                                               |
+| `storage.liaison.persistentVolumeClaims`                    | List of PVC configurations for liaison nodes            |                                                      |
+| `storage.liaison.persistentVolumeClaims[0].mountTargets`    | Mount targets for the PVC                               | `["measure","stream","trace"]`                       |
+| `storage.liaison.persistentVolumeClaims[0].claimName`       | Name of the PVC                                         | `liaison-data`                                       |
+| `storage.liaison.persistentVolumeClaims[0].size`            | Size of the PVC                                         | `10Gi`                                               |
+| `storage.liaison.persistentVolumeClaims[0].accessModes`     | Access modes for the PVC                                | `["ReadWriteOnce"]`                                  |
+| `storage.liaison.persistentVolumeClaims[0].storageClass`    | Storage class for the PVC                               | `nil`                                                |
+| `storage.liaison.persistentVolumeClaims[0].volumeMode`      | Volume mode for the PVC                                 | `Filesystem`                                         |
+| `storage.standalone.enabled`                                | Enable persistent storage for standalone mode (boolean) | `false`                                              |
+| `storage.standalone.persistentVolumeClaims`                 | List of PVC configurations for standalone               |                                                      |
+| `storage.standalone.persistentVolumeClaims[0].mountTargets` | Mount targets for the PVC                               | `["measure","stream","metadata","property","trace"]` |
+| `storage.standalone.persistentVolumeClaims[0].claimName`    | Name of the PVC                                         | `standalone-data`                                    |
+| `storage.standalone.persistentVolumeClaims[0].size`         | Size of the PVC                                         | `200Gi`                                              |
+| `storage.standalone.persistentVolumeClaims[0].accessModes`  | Access modes for the PVC                                | `["ReadWriteOnce"]`                                  |
+| `storage.standalone.persistentVolumeClaims[0].storageClass` | Storage class for the PVC                               | `nil`                                                |
+| `storage.standalone.persistentVolumeClaims[0].volumeMode`   | Volume mode for the PVC                                 | `Filesystem`                                         |
 
 ### Service account configuration
 
@@ -307,10 +315,11 @@ The content of this document describes the parameters that can be configured in 
 
 ### Etcd configuration for cluster state management
 
-| Name                | Description             | Value  |
-| ------------------- | ----------------------- | ------ |
-| `etcd.enabled`      | Enable etcd (boolean)   | `true` |
-| `etcd.replicaCount` | Number of etcd replicas | `1`    |
+| Name                    | Description                | Value                |
+| ----------------------- | -------------------------- | -------------------- |
+| `etcd.enabled`          | Enable etcd (boolean)      | `true`               |
+| `etcd.replicaCount`     | Number of etcd replicas    | `1`                  |
+| `etcd.image.repository` | Docker repository for etcd | `bitnamilegacy/etcd` |
 
 ### Authentication configuration for etcd
 


### PR DESCRIPTION
Bitnami has removed non-hardened, Debian-based software images from its free tier, under https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications.

This change forces us to rely on the "legacy" repository, which means the image will no longer receive updates. Therefore, our next step should be to explore other reliable and up-to-date repositories for etcd.