### PR TITLE
Validate generated resource names to avoid Kubernetes 63-byte limit errors

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -85,6 +85,69 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Validate a generated Kubernetes name does not exceed a byte limit.
+Usage: include "banyandb.validateNameLength" (dict "name" $name "limit" 63 "description" "..." "release" .Release.Name)
+*/}}
+{{- define "banyandb.validateNameLength" -}}
+{{- $name := .name -}}
+{{- $limit := .limit | default 63 -}}
+{{- $description := .description -}}
+{{- $release := .release -}}
+{{- if gt (len $name) (int $limit) }}
+{{- fail (printf "%s '%s' is %d bytes long, which exceeds the %d-byte Kubernetes limit. Shorten the Helm release name '%s' or set a shorter fullnameOverride." $description $name (len $name) $limit $release) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate all generated resource names fit within Kubernetes limits.
+StatefulSet names must leave room for the controller-revision-hash suffix
+(<statefulset-name>-<10-char-hash>) so pod labels stay within 63 bytes.
+*/}}
+{{- define "banyandb.validateNames" -}}
+{{- $fullname := include "banyandb.fullname" . -}}
+{{- $release := .Release.Name -}}
+
+{{/* fullname itself */}}
+{{- include "banyandb.validateNameLength" (dict "name" $fullname "limit" 63 "description" "Generated fullname" "release" $release) }}
+
+{{/* Standalone mode */}}
+{{- if .Values.standalone.enabled }}
+{{- include "banyandb.validateNameLength" (dict "name" $fullname "limit" 52 "description" "Standalone StatefulSet name" "release" $release) }}
+{{- end }}
+
+{{/* Cluster liaison */}}
+{{- if and .Values.cluster.enabled .Values.cluster.liaison }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-liaison" $fullname) "limit" 52 "description" "Liaison StatefulSet name" "release" $release) }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-liaison-headless" $fullname) "limit" 63 "description" "Liaison headless service name" "release" $release) }}
+{{- end }}
+
+{{/* Cluster data roles */}}
+{{- if and .Values.cluster.enabled .Values.cluster.data }}
+{{- range $roleName, $roleConfig := .Values.cluster.data.roles }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-data-%s" $fullname $roleName) "limit" 52 "description" (printf "Data StatefulSet name for role '%s'" $roleName) "release" $release) }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-data-%s-headless" $fullname $roleName) "limit" 63 "description" (printf "Data headless service name for role '%s'" $roleName) "release" $release) }}
+{{- end }}
+{{- end }}
+
+{{/* Auth Secret */}}
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-auth" $fullname) "limit" 63 "description" "Auth Secret name" "release" $release) }}
+{{- end }}
+
+{{/* Standalone UI */}}
+{{- if and .Values.cluster.enabled (eq .Values.cluster.ui.type "Standalone") }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-ui" $fullname) "limit" 63 "description" "UI Deployment name" "release" $release) }}
+{{- end }}
+
+{{/* FODC proxy */}}
+{{- if and .Values.cluster.enabled .Values.cluster.fodc.enabled }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-fodc-proxy" $fullname) "limit" 63 "description" "FODC proxy Deployment name" "release" $release) }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-fodc-proxy-grpc" $fullname) "limit" 63 "description" "FODC proxy gRPC service name" "release" $release) }}
+{{- include "banyandb.validateNameLength" (dict "name" (printf "%s-fodc-proxy-http" $fullname) "limit" 63 "description" "FODC proxy HTTP service name" "release" $release) }}
+{{- end }}
+{{- end }}
+
+{{/*
 SchemaStoragePropertyServerEnv - injects property server env vars (data node only)
 Includes: repair cron, schema server parameters, schema server TLS
 */}}

--- a/chart/templates/validate-names.yaml
+++ b/chart/templates/validate-names.yaml
@@ -1,0 +1,18 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- include "banyandb.validateNames" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,6 +21,10 @@
 ##
 
 ## @param fullnameOverride Override the full name of the chart
+## Keep this short enough that generated resource names stay within Kubernetes limits.
+## StatefulSet names must be <= 52 characters so the controller-revision-hash pod label
+## does not exceed 63 bytes. The chart will fail at render time if any generated name is
+## too long.
 ##
 fullnameOverride: ""
 ## @param nameOverride Override the name of the chart


### PR DESCRIPTION
## Summary

Adds a comprehensive name-length validation layer that fails at `helm install/upgrade` time before Kubernetes ever sees the resources.

## Problem

Long Helm release names cause StatefulSet pod labels to exceed the 63-byte Kubernetes limit. The StatefulSet controller appends a `controller-revision-hash` label in the form `<statefulset-name>-<10-char-hash>`, so StatefulSet names must be <= 52 bytes.

Example failure from a real deployment:

```
metadata.labels: Invalid value: "dr-test-2-prod-observability-manage-banyandb-data-hot-84bf98695d": must be no more than 63 bytes
```

## Changes

- Added `banyandb.validateNameLength` and `banyandb.validateNames` helpers in `chart/templates/_helpers.tpl`.
- `banyandb.validateNames` checks all generated resource names:
  - `fullname` itself (<= 63)
  - Standalone StatefulSet (<= 52)
  - Liaison StatefulSet and headless service
  - Data StatefulSet and headless service for every configured role
  - Auth Secret, UI Deployment, FODC proxy Deployment and services
- Invoked the validation helper from every resource template.
- Updated the `fullnameOverride` comment in `values.yaml` to document the constraint.

## Verification

- `helm lint chart/ --set image.tag=0.6.0` passes.
- Long release name now fails early with a clear message:
  ```
  Data StatefulSet name for role 'hot' 'dr-test-2-prod-observability-manage-banyandb-data-hot'
  is 53 characters long, which exceeds the 52-byte Kubernetes limit.
  Shorten the Helm release name 'dr-test-2-prod-observability-manage' or set a shorter fullnameOverride.
  ```
- Short release name or `fullnameOverride` renders successfully.
