### PR TITLE
Prepare for release 0.7.0-rc1

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,7 +16,7 @@
 apiVersion: v2
 name: skywalking-banyandb-helm
 home: https://skywalking.apache.org
-version: 0.7.0-rc0
+version: 0.7.0-rc1
 description: Helm Chart for Apache SkyWalking BanyanDB
 icon: https://raw.githubusercontent.com/apache/skywalking-kubernetes/master/logo/sw-logo-for-chart.jpg
 sources:


### PR DESCRIPTION
Bump chart version to 0.7.0-rc0 → 0.7.0-rc1 for the release candidate (includes the canopy console from #69).